### PR TITLE
fix: incorrect wallet storage

### DIFF
--- a/contracts_Tolk/01_jetton/jetton-utils.tolk
+++ b/contracts_Tolk/01_jetton/jetton-utils.tolk
@@ -5,6 +5,7 @@ fun calcDeployedJettonWallet(ownerAddress: address, minterAddress: address, jett
         jettonBalance: 0,
         ownerAddress,
         minterAddress,
+        jettonWalletCode,
     };
 
     return {

--- a/contracts_Tolk/01_jetton/storage.tolk
+++ b/contracts_Tolk/01_jetton/storage.tolk
@@ -3,6 +3,7 @@ struct WalletStorage {
     jettonBalance: coins
     ownerAddress: address
     minterAddress: address
+    jettonWalletCode: cell
 }
 
 struct MinterStorage {


### PR DESCRIPTION
WalletStorage struct is incomplete without jettonWalletCode inside which causes incorrectness jetton wallet address calculation in production systems.